### PR TITLE
Coolreader: fix font sizes

### DIFF
--- a/code/src/cr3/cr3_onyx/src/settings.h
+++ b/code/src/cr3/cr3_onyx/src/settings.h
@@ -25,7 +25,13 @@ namespace Ui {
 #define PROP_WINDOW_STYLE           "window.style"
 #define PROP_APP_START_ACTION       "cr3.app.start.action"
 
-#define DECL_DEF_CR_FONT_SIZES static int cr_font_sizes[] = { 14, 18, 20, 22, 24, 26, 28, 32, 38, 42, 48, 56, 64, 72 }
+#define DECL_DEF_CR_FONT_SIZES static int cr_font_sizes[] = { \
+        12, 13, 14, 15, 16, 17, 18, 19, \
+20, 21, 22, 23, 24, 25, 26, 27, 28, 29, \
+30, 31, 32, 33, 34, 35, 36, 37, 38, 39, \
+40, 41, 42, 43, 44, 45, 46, 47, 48, 49, \
+50, 51, 52, 53, 54, 55, 56, 57, 58, 59, \
+60 }
 
 class CR3View;
 class SettingsDlg : public QDialog {


### PR DESCRIPTION
Please, pull this small patch. Without this fix, setting some font sizes (for example, size 16) will work in current coolreader session, but when the coolreader is closed and started again, the size will be set back to 14.
