### PR TITLE
Reduce book rendering time on cr3 startup.

### DIFF
--- a/code/src/cr3/cr3_onyx/src/mainwindow.cpp
+++ b/code/src/cr3/cr3_onyx/src/mainwindow.cpp
@@ -155,8 +155,6 @@ OnyxMainWindow::OnyxMainWindow(QWidget *parent)
         }
     }
 
-    view_->loadDocument(file_name_to_open_);
-
     select_font_ = currentFont();
     font_family_actions_.loadExternalFonts();
 
@@ -177,6 +175,8 @@ OnyxMainWindow::OnyxMainWindow(QWidget *parent)
     view_->restoreWindowPos( this, "main.", true );
 
     loadDocumentOptions(file_name_to_open_);
+
+    view_->loadDocument(file_name_to_open_);
 
     view_->paintCitation();
 }


### PR DESCRIPTION
This is a small one. 
Options in cr3 are stored globally, not in the document object. It is safe to load a document after all settings has been loaded. It may limit numer of document rendering before it is displayed.

By 'render' I mean internal cr3 operations which converts cr3 logical layout into more roboust screen representation.,

My findings:
During my cr3 testing (via logging) I noticed that ducument is rendered mutiple times before it is displayed in screen. It is rendered at least one time too much when document will be displayed in full screen (without bottom system status bar). Document is rendered on inital load (1), then when window "position" and size are restored (2), then when it is resized to full screen (3).
Changes in this request will eliminate (2).
