### PR TITLE
cr3: update file_name_to_open_ on recent book load.

### DIFF
--- a/code/src/cr3/cr3_onyx/src/cr3widget.cpp
+++ b/code/src/cr3/cr3_onyx/src/cr3widget.cpp
@@ -252,8 +252,10 @@ vector<QString> CR3View::getRecentBooks()
     return books;
 }
 
-void CR3View::openRecentBook( int index )
+QString CR3View::openRecentBook( int index )
 {
+    QString fnRecent;
+
     _docview->swapToCache();
     _docview->updateCache();
     _docview->getDocument()->updateMap();
@@ -266,10 +268,13 @@ void CR3View::openRecentBook( int index )
         // TODO: check error
         if ( LVFileExists(fn) ) {
             //showWaitIcon();
-            loadDocument( cr2qt(fn) );
+            fnRecent = cr2qt(fn);
+            loadDocument( fnRecent );
         }
         //_docview->swapToCache();
     }
+
+    return fnRecent;
 }
 
 void CR3View::wheelEvent( QWheelEvent * event )

--- a/code/src/cr3/cr3_onyx/src/cr3widget.h
+++ b/code/src/cr3/cr3_onyx/src/cr3widget.h
@@ -49,7 +49,7 @@ class CR3View : public QWidget, public LVDocViewCallback
 
         bool loadDocument( QString fileName );
         vector<QString> getRecentBooks();
-        void openRecentBook(int index);
+        QString openRecentBook(int index);
 
         bool loadLastDocument();
         void setDocumentText( QString text );

--- a/code/src/cr3/cr3_onyx/src/mainwindow.cpp
+++ b/code/src/cr3/cr3_onyx/src/mainwindow.cpp
@@ -709,7 +709,8 @@ void OnyxMainWindow::processAdvancedActions()
             if (rb.popup(tr("Recent Books")) != QDialog::Accepted)
                break;
 
-            view_->openRecentBook(rb.selectedInfo());
+            QString fn = view_->openRecentBook(rb.selectedInfo());
+            if( !fn.isNull() ) file_name_to_open_ = fn;
             break;
                            }
         case ADD_CITATION:


### PR DESCRIPTION
file_name_to_open_ was not updated after one of the recent
books had been loaded. That affected the location of saved
settings and thumbnail on cr3 exit.
