### PR TITLE
cr3: change current position on UI action only.

### DIFF
--- a/code/src/cr3/crengine/include/lvdocview.h
+++ b/code/src/cr3/crengine/include/lvdocview.h
@@ -567,7 +567,7 @@ public:
     /// packs current file path and name
     lString16 getNavigationPath();
     /// returns pointer to bookmark/last position containter of currently opened file
-    CRFileHistRecord * getCurrentFileHistRecord();
+    CRFileHistRecord * getCurrentFileHistRecord(bool updateCurrentPos = false);
 	/// -1 moveto previous chapter, 0 to current chaoter first pae, 1 to next chapter
 	bool moveByChapter( int delta );
 	/// -1 moveto previous page, 1 to next page

--- a/code/src/cr3/crengine/src/lvdocview.cpp
+++ b/code/src/cr3/crengine/src/lvdocview.cpp
@@ -461,8 +461,11 @@ void LVDocView::checkPos() {
 		}
 	} else {
 		if (isPageMode()) {
+		    // do not change current position bookmark, just get page containing it
+		    ldomXPointer bm = _posBookmark;
 			int p = getBookmarkPage(_posBookmark);
 			goToPage(p);
+			_posBookmark = bm; // _posBookmark was set to the top left position; bm is still on the same page; restore it
 		} else {
 			//CRLog::trace("checkPos() _posBookmark node=%08X offset=%d", (unsigned)_posBookmark.getNode(), (int)_posBookmark.getOffset());
 			lvPoint pt = _posBookmark.toPoint();
@@ -3135,7 +3138,7 @@ void SaveBase64Objects( ldomNode * node )
 #endif
 
 /// returns pointer to bookmark/last position containter of currently opened file
-CRFileHistRecord * LVDocView::getCurrentFileHistRecord() {
+CRFileHistRecord * LVDocView::getCurrentFileHistRecord(bool updateCurrentPos) {
 	if (m_filename.empty())
 		return NULL;
 	CRLog::trace("LVDocView::getCurrentFileHistRecord()");
@@ -3143,8 +3146,13 @@ CRFileHistRecord * LVDocView::getCurrentFileHistRecord() {
 	lString16 title = getTitle();
 	lString16 authors = getAuthors();
 	lString16 series = getSeries();
-	CRLog::trace("get bookmark");
-	ldomXPointer bmk = getBookmark();
+	ldomXPointer bmk;
+	if( _posBookmark.isNull() || updateCurrentPos )	// current bookmark is needed; use existing if possible
+	{
+	    CRLog::trace("get bookmark");
+	    bmk = getBookmark();
+	}else
+	    bmk = _posBookmark;
     lString16 fn = m_filename;
 #ifdef ORIGINAL_FILENAME_PATCH
     if ( !m_originalFilename.empty() )
@@ -3159,7 +3167,7 @@ CRFileHistRecord * LVDocView::getCurrentFileHistRecord() {
 
 /// save last file position
 void LVDocView::savePosition() {
-	getCurrentFileHistRecord();
+	getCurrentFileHistRecord(true);
 }
 
 /// restore last file position


### PR DESCRIPTION
This pull request fixes the following problem:

Cool Reader 3 is not preserving last viewed page on document reload when a document is displayed in full screen (without system status bar at the bottom).

The problem is with LVDocView::checkPos() and  LVDocView::getCurrentFileHistRecord functions. Beside doing thier work these functions update current position to the first element on page. It is not necessary and wrong actually, as both pre-call current position and post-call current position are always on the same page.

Newly loaded document is rendered (with LCDocView::Render) at least twice before it is displayed in full screen. After that it is displayed on the screen. By then, current position may be different from the original one.

First render operation is performed for non-full screen page dimension; during that render operation original current position is altered and points to first element on page. Then, page is resized to full screen and next render operation is triggered. In most cases that element would fit a previous page (pages are larger and can hold more elements). In the end, wrong page is displayed to a user on document load.

LVDocView::checkPos()  is ment to assure that current position bookmark is on current page, if not then this function changes current page accordingly. New current page is determined from current position bookmark regardless if it was first element on page or one of the following. But page change operation reset a current postion bookmark to the first one on new page.

LVDocView::getCurrentFileHistRecord is ment to return all saved bookmarks for enumeration including current postion. It is using getBookmark() instead of already set _posBookmark, which holds actual current postion (when not null). getBookmark() returns a position to the first element on current page.

Handlers for any explicit user action which changes current position are unaffected.
