### PR TITLE
Allow link jumps to tags without text in cr3.

### DIFF
--- a/code/src/cr3/cr3_onyx/src/cr3widget.cpp
+++ b/code/src/cr3/cr3_onyx/src/cr3widget.cpp
@@ -187,12 +187,12 @@ LVTocItem * CR3View::getToc()
 }
 
 /// go to position specified by xPointer string
-void CR3View::goToXPointer(QString xPointer)
+void CR3View::goToXPointer(QString xPointer, bool linkTarget)
 {
     ldomXPointer p = _docview->getDocument()->createXPointer(qt2cr(xPointer));
     _docview->savePosToNavigationHistory();
     //if ( _docview->getViewMode() == DVM_SCROLL ) {
-    doCommand( DCMD_GO_POS, p.toPoint().y );
+    doCommand( DCMD_GO_POS, p.toPoint(linkTarget).y );
     //} else {
     //    doCommand( DCMD_GO_PAGE, item->getPage() );
     //}

--- a/code/src/cr3/cr3_onyx/src/cr3widget.h
+++ b/code/src/cr3/cr3_onyx/src/cr3widget.h
@@ -61,7 +61,7 @@ class CR3View : public QWidget, public LVDocViewCallback
         /// return LVDocView associated with widget
         LVDocView * getDocView() { return _docview; }
         /// go to position specified by xPointer string
-        void goToXPointer(QString xPointer);
+        void goToXPointer(QString xPointer, bool linkTarget = false);
 
         /// returns current page
         int getCurPage();

--- a/code/src/cr3/cr3_onyx/src/mainwindow.cpp
+++ b/code/src/cr3/cr3_onyx/src/mainwindow.cpp
@@ -932,7 +932,7 @@ void OnyxMainWindow::showTableOfContents()
     {
         return;
     }
-    view_->goToXPointer(index.data(Qt::UserRole+100).toString());
+    view_->goToXPointer(index.data(Qt::UserRole+100).toString(), true);
 }
 
 QStandardItem * OnyxMainWindow::searchParent(const int index,

--- a/code/src/cr3/crengine/include/lvtinydom.h
+++ b/code/src/cr3/crengine/include/lvtinydom.h
@@ -1258,9 +1258,9 @@ public:
 	}
 #if BUILD_LITE!=1
     /// returns caret rectangle for pointer inside formatted document
-    bool getRect(lvRect & rect) const;
+    bool getRect(lvRect & rect, bool linkTarget = false) const;
     /// returns coordinates of pointer inside formatted document
-    lvPoint toPoint() const;
+    lvPoint toPoint(bool linkTarget = false) const;
 #endif
     /// converts to string
 	lString16 toString();

--- a/code/src/cr3/crengine/src/lvdocview.cpp
+++ b/code/src/cr3/crengine/src/lvdocview.cpp
@@ -4247,7 +4247,7 @@ int LVDocView::getBookmarkPage(ldomXPointer bm) {
 	if (bm.isNull()) {
 		return 0;
 	} else {
-		lvPoint pt = bm.toPoint();
+		lvPoint pt = bm.toPoint(true);
 		if (pt.y < 0)
 			return 0;
 		return m_pages.FindNearestPage(pt.y, 0);

--- a/code/src/cr3/crengine/src/lvtinydom.cpp
+++ b/code/src/cr3/crengine/src/lvtinydom.cpp
@@ -4777,16 +4777,16 @@ ldomXPointer ldomDocument::createXPointer( lvPoint pt, int direction )
 }
 
 /// returns coordinates of pointer inside formatted document
-lvPoint ldomXPointer::toPoint() const
+lvPoint ldomXPointer::toPoint(bool linkTarget) const
 {
     lvRect rc;
-    if ( !getRect( rc ) )
+    if ( !getRect( rc, linkTarget ) )
         return lvPoint(-1, -1);
     return rc.topLeft();
 }
 
 /// returns caret rectangle for pointer inside formatted document
-bool ldomXPointer::getRect(lvRect & rect) const
+bool ldomXPointer::getRect(lvRect & rect, bool linkTarget) const
 {
     //CRLog::trace("ldomXPointer::getRect()");
     if ( isNull() )
@@ -4892,7 +4892,16 @@ bool ldomXPointer::getRect(lvRect & rect) const
         }
         if ( srcIndex == -1 ) {
             if ( lastIndex<0 )
+            {
+                if( linkTarget && (p0->hasAttribute(attr_id) || p0->hasAttribute(attr_name)) )
+                {   // set top left corner position inside page; height & length are not used for link targets
+                    rect.left = r.getX() + rc.left;
+                    rect.top = r.getY() + rc.top;
+                    rect.right = rect.bottom = 0;
+                    return true;
+                }
                 return false;
+            }
             srcIndex = lastIndex;
             srcLen = lastLen;
             offset = lastOffset;


### PR DESCRIPTION
Some books specify empty tags as TOC link targets, like:
<a id="someId"> </a>. CR3 is jumping to page 0 instead.

The problem is that ldomXPointer::getRect returns false when there is not text and rect is empty. I've modified that behavior and when explicitly set (call parameter linkTarget set to true) it returns true and top left corrdinates of the rect returned are set correctly. Those two corrdinates are used only when a link target page is determined and that is the only scenario when getRect is called with linkTarget parameter set to true (TOC jump, link on page jump).
