### PR TITLE
looses precision error on x86_64 fixed

### DIFF
--- a/code/src/rss_reader/rss_reader_view.cpp
+++ b/code/src/rss_reader/rss_reader_view.cpp
@@ -476,7 +476,7 @@ void RssReaderView::createListView()
         dd->insert(TAG_ROW, i);
         list_data_.push_back(dd);
 
-        dd->insert(TAG_POINTER, (int)info);
+        dd->insert(TAG_POINTER, *((int*)(&info)));
         info->AssociateListItem(dd);
 
         if (info->Selected && selected_data.size() < ROWS)


### PR DESCRIPTION
During build on x86_64 with strict_warning enabled caused error.
